### PR TITLE
Fix size() bug

### DIFF
--- a/lineHighlight.pde
+++ b/lineHighlight.pde
@@ -5,9 +5,15 @@ Segment seg3;
 int clicks = 0;
 ArrayList<Segment> segs;
 boolean flag = true;
-void setup()
+
+void settings()
 {
     size(800,900);
+}
+
+void setup()
+{
+    //size(800,900);
     
     //rect(0, 0, 800, 800);
     button = new Button("Click", 10, 825, 100, 35);


### PR DESCRIPTION
For some reason, the example lineHighlight.pde wouldn't work on my machine (Mac, Processing 3). 

It always errored, throwing: "size() cannot be used here, see https://processing.org/reference/size_.html"

I found [this Github issue](https://github.com/processing/processing-docs/issues/298) about the problem, and people said the solution is to move size() call into settings rather than setup. 

PR does that, and works on my machine. Proposing the change so that any other 345 students who try to pull this repo down and run it themselves won't have it break on them too. 